### PR TITLE
Added DDL generation from JPA entities

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  db:
+    image: docker.io/postgres:latest
+    environment:
+      POSTGRES_PASSWORD: tododb
+      POSTGRES_USER: tododb
+      POSTGRES_DB: todo
+

--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -69,6 +69,14 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-pg-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-config-kubernetes-configmap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-config</artifactId>
+        </dependency>
         <!-- CHOOSE THE DATABASE DRIVER OR INSERT YOUR OWN
             <dependency>
               <groupId>io.reactiverse</groupId>

--- a/modules/models/pom.xml
+++ b/modules/models/pom.xml
@@ -147,6 +147,22 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>de.jpdigital</groupId>
+                <artifactId>hibernate54-ddl-maven-plugin</artifactId>
+                <version>2.4.0</version>
+                <configuration>
+                    <dialects>POSTGRESQL</dialects>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>gen-ddl</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.1.0</version>


### PR DESCRIPTION
Resolves #3 

Added the `hibernate54-ddl-maven-plugin` and configured it to run as part of the `generate-sources` Maven lifecycle phase. It will analyze the JPA entities in the Models module and create PostgreSQL DDL for the tables/fields.